### PR TITLE
Change image sources to remote URLs in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_logo.png" width="256"/>
-    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_nest_logo.png" width="256"/>
-    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/cp_editorial_logo.png" width="256"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_logo.png" width="256" alt="Coduck logo"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_nest_logo.png" width="256" alt="Coduck Nest logo"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/cp_editorial_logo.png" width="256" alt="CP Editorial logo"/>
 </p>
 
 # Welcome to Coduck Project

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-    <img src="./coduck_logo.png" width="256"/>
-    <img src="./coduck_nest_logo.png" width="256"/>
-    <img src="./cp_editorial_logo.png" width="256"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_logo.png" width="256"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/coduck_nest_logo.png" width="256"/>
+    <img src="https://raw.githubusercontent.com/Coduck-Team/.github/main/profile/cp_editorial_logo.png" width="256"/>
 </p>
 
 # Welcome to Coduck Project


### PR DESCRIPTION
Updated image sources in README to use URLs instead of local paths.

cc: https://github.com/orgs/community/discussions/135078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated image references in the profile README to use externally hosted URLs so logos display reliably in the rendered documentation.
  * No other welcome or descriptive content was changed; formatting and text remain intact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Coduck-Team/.github/pull/7)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->